### PR TITLE
Modified kRnel to compile and run with rust 0.9

### DIFF
--- a/src/drivers/io/console/arch/x86_64/console.rs
+++ b/src/drivers/io/console/arch/x86_64/console.rs
@@ -1,6 +1,3 @@
-#[author = "Arcterus"];
-#[license = "MPL v2.0"];
-
 pub static SCREEN_ADDR: uint = 0xb8000;
 pub static MAX_ROW: uint = 25;
 pub static MAX_COLUMN: uint = 80;

--- a/src/drivers/io/console/arch/x86_64/console.rs
+++ b/src/drivers/io/console/arch/x86_64/console.rs
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2014 Arcterus@mail.com
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */ 
 pub static SCREEN_ADDR: uint = 0xb8000;
 pub static MAX_ROW: uint = 25;
 pub static MAX_COLUMN: uint = 80;

--- a/src/drivers/io/console/arch/x86_64/console.rs
+++ b/src/drivers/io/console/arch/x86_64/console.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Arcterus@mail.com
+ * Copyright (c) 2014 Arcterus
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/drivers/io/console/mod.rs
+++ b/src/drivers/io/console/mod.rs
@@ -1,5 +1,3 @@
-#[author = "Arcterus"];
-#[license = "MPL v2.0"];
 
 pub use self::target::*;
 use runtime::iter;
@@ -70,10 +68,10 @@ pub fn color_println(msg: &str, foreground: Color, background: Color) {
 
 pub fn color_print(msg: &str, foreground: Color, background: Color) {
 	unsafe {
-		do msg.each_byte() |byte| {
+		msg.each_byte(|byte| {
 			print_byte(byte, foreground, background);
 			true
-		};
+		});
 		move_cursor(row, col);
 	}
 }
@@ -121,9 +119,9 @@ fn print_byte(byte: u8, foreground: Color, background: Color) {
 
 pub fn color_clear_screen(background: Color) {
 	unsafe {
-		do iter::range(0, MAX_ROW) |i| {
+		iter::range(0, MAX_ROW,|i| {
 			clear_line(*i, background);
-		};
+		});
 		row = 0;
 		col = 0;
 		move_cursor(0, 0);
@@ -145,11 +143,11 @@ fn clear_line(_row: uint, background: Color) {
 fn clear_rem_line(background: Color) {
 	unsafe {
 		let rpos = row * MAX_COLUMN;
-		do iter::range(col, MAX_COLUMN) |i| {
+		iter::range(col, MAX_COLUMN, |i| {
 			let pos = rpos + *i;
 			(*SCREEN)[pos].char = ' ' as u8;
 			(*SCREEN)[pos].attr = ((background as u8) << 4) + (FOREGROUND_COLOR as u8);
-		}
+		})
 	}
 }
 
@@ -167,16 +165,16 @@ fn add_line(background: Color) {
 
 fn shift_rows_up() {
 	unsafe {
-		do iter::range(1, MAX_ROW) |r| {
+		iter::range(1, MAX_ROW, |r| {
 			let fposr = *r * MAX_COLUMN;
 			let tposr = fposr - MAX_COLUMN;
-			do iter::range(0, MAX_COLUMN) |c| {
+			iter::range(0, MAX_COLUMN, |c| {
 				let tpos = tposr + *c;
 				let fpos = fposr + *r;
 				(*SCREEN)[tpos].char = (*SCREEN)[fpos].char;
 				(*SCREEN)[tpos].attr = (*SCREEN)[fpos].attr;
-			}
-		}
+			});
+		});
 	}
 	clear_line(MAX_ROW - 1, BACKGROUND_COLOR);
 }

--- a/src/drivers/io/console/mod.rs
+++ b/src/drivers/io/console/mod.rs
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2014 Arcterus@mail.com
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */ 
 
 pub use self::target::*;
 use runtime::iter;

--- a/src/drivers/io/console/mod.rs
+++ b/src/drivers/io/console/mod.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Arcterus@mail.com
+ * Copyright (c) 2014 Arcterus
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/kernel/arch/x86_64/reset.rs
+++ b/src/kernel/arch/x86_64/reset.rs
@@ -1,5 +1,3 @@
-#[author = "Arcterus"];
-#[license = "MPL v2.0"];
 
 pub unsafe fn immediate_reset() {
 	asm!("xor %eax, %eax; lidt $0; int3" :: "m" (0 as *u64));

--- a/src/kernel/arch/x86_64/reset.rs
+++ b/src/kernel/arch/x86_64/reset.rs
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2014 Arcterus@mail.com
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */ 
 
 pub unsafe fn immediate_reset() {
 	asm!("xor %eax, %eax; lidt $0; int3" :: "m" (0 as *u64));

--- a/src/kernel/arch/x86_64/reset.rs
+++ b/src/kernel/arch/x86_64/reset.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Arcterus@mail.com
+ * Copyright (c) 2014 Arcterus
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/kernel/error.rs
+++ b/src/kernel/error.rs
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2014 Arcterus@mail.com
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */ 
 
 use super::console;
 

--- a/src/kernel/error.rs
+++ b/src/kernel/error.rs
@@ -1,5 +1,3 @@
-#[author = "Arcterus"];
-#[license = "MPL v2.0"];
 
 use super::console;
 

--- a/src/kernel/error.rs
+++ b/src/kernel/error.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Arcterus@mail.com
+ * Copyright (c) 2014 Arcterus
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/kernel/main.rs
+++ b/src/kernel/main.rs
@@ -1,11 +1,15 @@
 /*
- * Copyright (c) 2014 Arcterus@mail.com
+ * Copyright (c) 2014 Arcterus
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */ 
-#[crate_id = "kRnel#0.0.1"];
+#[crate_id(name = "kRnel",
+           vers = "0.0.1",
+           author = "Arcterus",
+           license = "MPL v2.0")];
+
 
 #[allow(ctypes)];
 #[no_std];
@@ -37,7 +41,7 @@ pub mod error;
 #[start]
 pub fn main() {
 	console::clear_screen();
-	console::print("iiiiiiiiiiiiiiiiiiiiiiiiiii\niiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiii\x08\x08\x08\x08\x08test");	
+	console::print("iiiiiiiiiiiiiiiiiiiiiiiiiii\niiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiii\x08\x08\x08\x08\x08test");
 	console::println("");
 	error::panic("End of kernel");
 }

--- a/src/kernel/main.rs
+++ b/src/kernel/main.rs
@@ -1,10 +1,10 @@
-#[link(name = "kRnel",
-       vers = "0.0.1",
-       author = "Arcterus",
-       license = "MPL v2.0")];
+#[crate_id = "kRnel#0.0.1"];
 
 #[allow(ctypes)];
 #[no_std];
+#[feature(globs)];
+#[feature(asm)];
+
 
 pub use drivers::io::console;
 pub use target::reset::*;
@@ -19,7 +19,7 @@ pub mod runtime;
 
 #[path = "../drivers"]
 mod drivers {
-	mod io {
+	pub mod io {
 		pub mod console;
 	}
 }

--- a/src/kernel/main.rs
+++ b/src/kernel/main.rs
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2014 Arcterus@mail.com
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */ 
 #[crate_id = "kRnel#0.0.1"];
 
 #[allow(ctypes)];
@@ -30,7 +37,7 @@ pub mod error;
 #[start]
 pub fn main() {
 	console::clear_screen();
-	console::print("iiiiiiiiiiiiiiiiiiiiiiiiiii\niiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiii\x08\x08\x08\x08\x08test");
+	console::print("iiiiiiiiiiiiiiiiiiiiiiiiiii\niiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiii\x08\x08\x08\x08\x08test");	
 	console::println("");
 	error::panic("End of kernel");
 }

--- a/src/runtime/device.rs
+++ b/src/runtime/device.rs
@@ -1,6 +1,3 @@
-#[author = "Arcterus"];
-#[license = "MPL v2.0"];
-
 pub trait BlockDevice {
 
 }

--- a/src/runtime/device.rs
+++ b/src/runtime/device.rs
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2014 Arcterus@mail.com
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */ 
 pub trait BlockDevice {
 
 }

--- a/src/runtime/device.rs
+++ b/src/runtime/device.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Arcterus@mail.com
+ * Copyright (c) 2014 Arcterus
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/runtime/iter.rs
+++ b/src/runtime/iter.rs
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2014 Arcterus@mail.com
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */ 
 use super::zero::*;
 use super::num::*;
 
@@ -39,4 +46,3 @@ pub fn range_step<A: Add<A, A> + Ord + One>(start: A, end: A, step: A, it: |&A| 
 pub fn range_step_inclusive<A: Add<A, A> + Ord + One>(start: A, end: A, step: A, it: |&A| -> () ) {
 	range_step(start, end + One::one(), step, it);
 }
-

--- a/src/runtime/iter.rs
+++ b/src/runtime/iter.rs
@@ -1,15 +1,12 @@
-#[author = "Arcterus"];
-#[license = "MPL v2.0"];
-
 use super::zero::*;
 use super::num::*;
 
 #[inline]
-pub fn iterate<A: Add<A, A> + Ord + One>(start: A, end: A, it: &fn(elem: &A) -> bool) -> bool {
+pub fn iterate<A: Add<A, A> + Ord + One>(start: A, end: A, it: |&A| -> bool) -> bool {
 	iterate_step(start, end, One::one(), it)
 }
 
-pub fn iterate_step<A: Add<A, A> + Ord + One>(start: A, end: A, step: A, it: &fn(elem: &A) -> bool) -> bool {
+pub fn iterate_step<A: Add<A, A> + Ord + One>(start: A, end: A, step: A, it: |&A| -> bool) -> bool {
 	let mut start = start;
 	while start < end {
 		if !it(&start) {
@@ -21,16 +18,16 @@ pub fn iterate_step<A: Add<A, A> + Ord + One>(start: A, end: A, step: A, it: &fn
 }
 
 #[inline]
-pub fn range<A: Add<A, A> + Ord + One>(start: A, end: A, it: &fn(elem: &A)) {
+pub fn range<A: Add<A, A> + Ord + One>(start: A, end: A, it: |&A| -> () ) {
 	range_step(start, end, One::one(), it);
 }
 
 #[inline]
-pub fn range_inclusive<A: Add<A, A> + Ord + One>(start: A, end: A, it: &fn(elem: &A)) {
+pub fn range_inclusive<A: Add<A, A> + Ord + One>(start: A, end: A, it: |&A| -> () ) {
 	range_step_inclusive(start, end, One::one(), it);
 }
 
-pub fn range_step<A: Add<A, A> + Ord + One>(start: A, end: A, step: A, it: &fn(elem: &A)) {
+pub fn range_step<A: Add<A, A> + Ord + One>(start: A, end: A, step: A, it: |&A| -> () ) {
 	let mut start = start;
 	while start < end {
 		it(&start);
@@ -39,7 +36,7 @@ pub fn range_step<A: Add<A, A> + Ord + One>(start: A, end: A, step: A, it: &fn(e
 }
 
 #[inline]
-pub fn range_step_inclusive<A: Add<A, A> + Ord + One>(start: A, end: A, step: A, it: &fn(elem: &A)) {
+pub fn range_step_inclusive<A: Add<A, A> + Ord + One>(start: A, end: A, step: A, it: |&A| -> () ) {
 	range_step(start, end + One::one(), step, it);
 }
 

--- a/src/runtime/iter.rs
+++ b/src/runtime/iter.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Arcterus@mail.com
+ * Copyright (c) 2014 Arcterus
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Arcterus@mail.com
+ * Copyright (c) 2014 Arcterus
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -23,7 +23,6 @@ pub mod str;
 // Failure
 
 #[lang="fail_"]
-#[fixed_stack_segment]
 pub fn fail(expr: *u8, file: *u8, line: uint) -> ! {
 	unsafe {
 		console::color_print("Error", console::Red, console::BACKGROUND_COLOR);
@@ -38,7 +37,6 @@ pub fn fail(expr: *u8, file: *u8, line: uint) -> ! {
 }
 
 #[lang="fail_bounds_check"]
-#[fixed_stack_segment]
 pub fn fail_bounds_check(_: *i8, _: uint, _: uint, _: uint) {
     unsafe {
         zero::abort()

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1,5 +1,3 @@
-#[author = "Arcterus"];
-#[license = "MPL v2.0"];
 
 use self::zero::size_of;
 use super::console;

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2014 Arcterus@mail.com
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */ 
 
 use self::zero::size_of;
 use super::console;

--- a/src/runtime/num.rs
+++ b/src/runtime/num.rs
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2014 Arcterus@mail.com
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */ 
 pub trait One {
 	fn one() -> Self;
 }

--- a/src/runtime/num.rs
+++ b/src/runtime/num.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Arcterus@mail.com
+ * Copyright (c) 2014 Arcterus
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/runtime/num.rs
+++ b/src/runtime/num.rs
@@ -1,10 +1,7 @@
-#[author = "Arcterus"];
-#[license = "MPL v2.0"];
-
 pub trait One {
 	fn one() -> Self;
 }
 
 pub trait Times {
-	fn times(&self, it: &fn());
+	fn times(&self, it: || -> () );
 }

--- a/src/runtime/option.rs
+++ b/src/runtime/option.rs
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2014 Arcterus@mail.com
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */ 
 
 pub enum Option<T> {
 	Some(T),

--- a/src/runtime/option.rs
+++ b/src/runtime/option.rs
@@ -1,5 +1,3 @@
-#[author = "Arcterus"];
-#[license = "MPL v2.0"];
 
 pub enum Option<T> {
 	Some(T),

--- a/src/runtime/option.rs
+++ b/src/runtime/option.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Arcterus@mail.com
+ * Copyright (c) 2014 Arcterus
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/runtime/ptr.rs
+++ b/src/runtime/ptr.rs
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2014 Arcterus@mail.com
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */ 
 
 use runtime::zero::{Eq};
 

--- a/src/runtime/ptr.rs
+++ b/src/runtime/ptr.rs
@@ -1,5 +1,3 @@
-#[author = "Arcterus"];
-#[license = "MPL v2.0"];
 
 use runtime::zero::{Eq};
 

--- a/src/runtime/ptr.rs
+++ b/src/runtime/ptr.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Arcterus@mail.com
+ * Copyright (c) 2014 Arcterus
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/runtime/result.rs
+++ b/src/runtime/result.rs
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2014 Arcterus@mail.com
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */ 
 
 pub enum Result<T, U> {
 	Ok(T),

--- a/src/runtime/result.rs
+++ b/src/runtime/result.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Arcterus@mail.com
+ * Copyright (c) 2014 Arcterus
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/runtime/result.rs
+++ b/src/runtime/result.rs
@@ -1,5 +1,3 @@
-#[author = "Arcterus"];
-#[license = "MPL v2.0"];
 
 pub enum Result<T, U> {
 	Ok(T),

--- a/src/runtime/str.rs
+++ b/src/runtime/str.rs
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2014 Arcterus@mail.com
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */ 
 use super::iter;
 use super::zero::transmute;
 
@@ -43,4 +50,3 @@ pub fn as_buf<T>(s: &str, func: |*u8, uint| -> T) -> T {
 		func(buf, len)
 	}
 }
-

--- a/src/runtime/str.rs
+++ b/src/runtime/str.rs
@@ -1,6 +1,3 @@
-#[author = "Arcterus"];
-#[license = "MPL v2.0"];
-
 use super::iter;
 use super::zero::transmute;
 
@@ -10,36 +7,36 @@ pub trait Str {
 
 pub trait StrSlice {
 	fn len(&self) -> uint;
-	fn each_byte(&self, it: &fn(u8) -> bool) -> bool;
+	fn each_byte(&self, it: |u8| -> bool) -> bool;
 }
 
-impl<'self> Str for &'self str {
+impl<'a> Str for &'a str {
 	fn as_slice<'a>(&'a self) -> &'a str {
 		*self
 	}
 }
 
-impl<'self> Str for ~str {
+impl Str for ~str {
 	fn as_slice<'a>(&'a self) -> &'a str {
 		let s: &'a str = *self;
 		s
 	}
 }
 
-impl<'self> StrSlice for &'self str {
+impl<'a> StrSlice for &'a str {
 	#[inline]
 	fn len(&self) -> uint {
-		do as_buf(*self) |_, size| {
+		as_buf(*self,|_, size| {
 			size
-		}
+		})
 	}
 
-	fn each_byte(&self, it: &fn(u8) -> bool) -> bool {
-		do iter::iterate(0, self.len()) |i| { it(self[*i]) }
+	fn each_byte(&self, it: |u8| -> bool) -> bool {
+		iter::iterate(0, self.len(),|i| { it(self[*i]) })
 	}
 }
 
-pub fn as_buf<T>(s: &str, func: &fn(*u8, uint) -> T) -> T {
+pub fn as_buf<T>(s: &str, func: |*u8, uint| -> T) -> T {
 	unsafe {
 		let v: *(*u8, uint) = transmute(&s);
 		let (buf, len) = *v;

--- a/src/runtime/str.rs
+++ b/src/runtime/str.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Arcterus@mail.com
+ * Copyright (c) 2014 Arcterus
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/runtime/uint.rs
+++ b/src/runtime/uint.rs
@@ -1,6 +1,3 @@
-#[author = "Arcterus"];
-#[license = "MPL v2.0"];
-
 use super::iter;
 use super::num;
 use super::zero;
@@ -32,8 +29,8 @@ impl zero::Ord for uint {
 
 impl num::Times for uint {
 	#[inline]
-	fn times(&self, it: &fn()) {
-		iter::range(0, *self, |_| { it(); });
+	fn times(&self, it: || -> () ) {
+		iter::range(0, *self,|_| { it(); });
 	}
 }
 

--- a/src/runtime/uint.rs
+++ b/src/runtime/uint.rs
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2014 Arcterus@mail.com
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */ 
 use super::iter;
 use super::num;
 use super::zero;
@@ -33,4 +40,3 @@ impl num::Times for uint {
 		iter::range(0, *self,|_| { it(); });
 	}
 }
-

--- a/src/runtime/uint.rs
+++ b/src/runtime/uint.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Arcterus@mail.com
+ * Copyright (c) 2014 Arcterus
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/runtime/vec.rs
+++ b/src/runtime/vec.rs
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2014 Arcterus@mail.com
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */ 
 
 /*mod raw {
 	struct VecRepr {

--- a/src/runtime/vec.rs
+++ b/src/runtime/vec.rs
@@ -1,5 +1,3 @@
-#[author = "Arcterus"];
-#[license = "MPL v2.0"];
 
 /*mod raw {
 	struct VecRepr {

--- a/src/runtime/vec.rs
+++ b/src/runtime/vec.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Arcterus@mail.com
+ * Copyright (c) 2014 Arcterus
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/runtime/zero.rs
+++ b/src/runtime/zero.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Arcterus@mail.com
+ * Copyright (c) 2014 Arcterus
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -267,11 +267,8 @@ pub unsafe fn check_not_borrowed(_: *u8, _: *i8, _: uint) {
 // libc dependencies
 
 extern {
-    #[fast_ffi]
     pub fn malloc(size: uint) -> *u8;
-    #[fast_ffi]
     pub fn free(ptr: *u8);
-    #[fast_ffi]
     pub fn abort() -> !;
 }
 

--- a/src/runtime/zero.rs
+++ b/src/runtime/zero.rs
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2014 Arcterus@mail.com
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */ 
 // Copyright (c) 2006-2009 Graydon Hoare
 // Copyright (c) 2009-2013 Mozilla Foundation
 
@@ -274,4 +281,3 @@ extern "rust-intrinsic" {
     pub fn transmute<T,U>(val: T) -> U;
     pub fn size_of<T>() -> uint;
 }
-

--- a/src/runtime/zero.rs
+++ b/src/runtime/zero.rs
@@ -201,7 +201,6 @@ struct Header {
 
 // FIXME: This is horrendously inefficient.
 #[lang="exchange_malloc"]
-#[fixed_stack_segment]
 pub unsafe fn exchange_malloc(type_desc: *i8, size: uint) -> *i8 {
     let alloc: *mut Header = transmute(malloc(size_of::<Header>() + size));
     (*alloc).minus_one = -1;
@@ -212,7 +211,6 @@ pub unsafe fn exchange_malloc(type_desc: *i8, size: uint) -> *i8 {
 }
 
 #[lang="exchange_free"]
-#[fixed_stack_segment]
 pub unsafe fn exchange_free(alloc: *i8) {
     free(transmute(alloc))
 }
@@ -220,49 +218,41 @@ pub unsafe fn exchange_free(alloc: *i8) {
 // The nonexistent garbage collector
 
 #[lang="malloc"]
-#[fixed_stack_segment]
 pub unsafe fn gc_malloc(_: *i8, _: uint) -> *i8 {
     abort()
 }
 
 #[lang="free"]
-#[fixed_stack_segment]
 pub unsafe fn gc_free(_: *i8) {
     abort()
 }
 
 #[lang="borrow_as_imm"]
-#[fixed_stack_segment]
 pub unsafe fn borrow_as_imm(_: *u8, _: *i8, _: uint) -> uint {
     abort()
 }
 
 #[lang="borrow_as_mut"]
-#[fixed_stack_segment]
 pub unsafe fn borrow_as_mut(_: *u8, _: *i8, _: uint) -> uint {
     abort()
 }
 
 #[lang="record_borrow"]
-#[fixed_stack_segment]
 pub unsafe fn record_borrow(_: *u8, _: uint, _: *i8, _: uint) {
     abort()
 }
 
 #[lang="unrecord_borrow"]
-#[fixed_stack_segment]
 pub unsafe fn unrecord_borrow(_: *u8, _: uint, _: *i8, _: uint) {
     abort()
 }
 
 #[lang="return_to_mut"]
-#[fixed_stack_segment]
 pub unsafe fn return_to_mut(_: *u8, _: uint, _: *i8, _: uint) {
     abort()
 }
 
 #[lang="check_not_borrowed"]
-#[fixed_stack_segment]
 pub unsafe fn check_not_borrowed(_: *u8, _: *i8, _: uint) {
     abort()
 }

--- a/tools/gen_binutils.sh
+++ b/tools/gen_binutils.sh
@@ -21,7 +21,7 @@ if [ ! -f install/bin/x86_64-linux-elf-ld ]; then
 	echo "Configure binutils"
 	CC=clang CFLAGS='-Wno-string-plus-int -Wno-empty-body -Wno-self-assign' \
 		./configure --prefix=/ --target=x86_64-linux-elf --enable-ld \
-		--disable-gold || exit 1
+		--disable-gold --disable-werror || exit 1
 	echo "Building binutils"
 	make -j4 || exit 1
 	echo "Installing binutils"


### PR DESCRIPTION
Modified the source to compile with rust 0.9. 

As part of this I removed all the #[author = "..."] and #[license = "..."] attributes since they are not supported in 0.9 I don't know I am going to submit another pull request that add in the traditional license block and a license file. 
